### PR TITLE
Let x86_64 CallWithMRs

### DIFF
--- a/libsel4/tools/syscall_stub_gen.py
+++ b/libsel4/tools/syscall_stub_gen.py
@@ -58,6 +58,7 @@ WORD_SIZE_BITS_ARCH = {
 MESSAGE_REGISTERS_FOR_ARCH = {
     "aarch32": 4,
     "ia32": 2,
+    "x86_64": 2,
     "arm_hyp": 4,
 }
 


### PR DESCRIPTION
- `syscall_stub_gen.py` now works on x86_64 without passing `--buffer`
- _All is well in the universe_ with x86_64 in qemu if I remove `--buffer` from the `libsel4` Makefile
